### PR TITLE
use bit packing of edge lists to speedup hashing

### DIFF
--- a/src/decompositions.jl
+++ b/src/decompositions.jl
@@ -52,17 +52,30 @@ function tet_to_edges!(pair::Vector, pair_set::Set, t)
         for ep in 1:6
             p1 = t[i][tetpairs[ep][1]]
             p2 = t[i][tetpairs[ep][2]]
-            push!(pair_set, p1 > p2 ? (p2,p1) : (p1,p2))
+            push!(pair_set, p1 > p2 ? bitpack(p2,p1) : bitpack(p1,p2))
         end
     end
     resize!(pair, length(pair_set))
     # copy pair set to array since sets are not sortable
     i = 1
     for elt in pair_set
-        pair[i] = elt
+        pair[i] = unbitpack(elt)
         i = i + 1
     end
 
     # sort the edge pairs for better point lookup
     sort!(pair)
+end
+
+"""
+Pack two 32 bit numbers (or smaller) in an UInt64 to speed up hashing in dicts
+"""
+function bitpack(xi,yi)
+    (unsafe_trunc(UInt64, xi) << 32) | unsafe_trunc(UInt64, yi)
+end
+
+function unbitpack(key)
+    # we can use unsafe truncation here because the bounds
+    # are enforced in the initial masking.
+    unsafe_trunc(UInt32, key >>> 32), unsafe_trunc(UInt32, key)
 end

--- a/src/distmeshnd.jl
+++ b/src/distmeshnd.jl
@@ -83,7 +83,7 @@ function distmesh(fdist::Function,
 
     # arrays for tracking quality metrics
     tris = NTuple{3,Int32}[]        # triangles used for quality checks
-    triset = Set{NTuple{3,Int32}}() # set for triangles to ensure uniqueness
+    triset = Set{UInt64}() # set for triangles to ensure uniqueness
     qualities = eltype(VertType)[]
 
     # information on each iteration

--- a/src/distmeshnd.jl
+++ b/src/distmeshnd.jl
@@ -72,7 +72,7 @@ function distmesh(fdist::Function,
     end
 
     # initialize arrays
-    pair_set = Set{Tuple{Int32,Int32}}()        # set used for ensure we have a unique set of edges
+    pair_set = Set{UInt64}()        # set used for ensure we have a unique set of edges
     pair = Tuple{Int32,Int32}[]                 # edge indices (Int32 since we use Tetgen)
     dp = zeros(VertType, length(p))             # displacement at each node
     bars = VertType[]                           # the vector of each edge


### PR DESCRIPTION
Gains vary but are generally about 25%. This should also work for triangles, reducing the overhead of quality checks for refinement. 