### PR TITLE
Sjk/opt2

### DIFF
--- a/src/decompositions.jl
+++ b/src/decompositions.jl
@@ -48,21 +48,24 @@ end
 """
 function tet_to_edges!(pair::Vector, pair_set::Set, t)
     empty!(pair_set)
+    empty!(pair)
     @inbounds for i in eachindex(t)
         for ep in 1:6
             p1 = t[i][tetpairs[ep][1]]
             p2 = t[i][tetpairs[ep][2]]
-            push!(pair_set, p1 > p2 ? (p2,p1) : (p1,p2))
+            elt = p1 > p2 ? (p2,p1) : (p1,p2)
+            if !in(bitpack(elt[1],elt[2]), pair_set)
+                push!(pair_set, bitpack(elt[1],elt[2]))
+                push!(pair, elt)
+            end
         end
     end
-    resize!(pair, length(pair_set))
-    # copy pair set to array since sets are not sortable
-    i = 1
-    @inbounds for elt in pair_set
-        pair[i] = elt
-        i = i + 1
-    end
-
     # sort the edge pairs for better point lookup
-    sort!(pair)
+    # TODO This seems to be really good for some geoemetries,
+    # but intoduces larger performance regressions for others
+    #sort!(pair)
+end
+
+function bitpack(xi,yi)
+    (unsafe_trunc(UInt64, xi) << 32) | unsafe_trunc(UInt64, yi)
 end

--- a/src/decompositions.jl
+++ b/src/decompositions.jl
@@ -48,7 +48,7 @@ end
 """
 function tet_to_edges!(pair::Vector, pair_set::Set, t)
     empty!(pair_set)
-    for i in eachindex(t)
+    @inbounds for i in eachindex(t)
         for ep in 1:6
             p1 = t[i][tetpairs[ep][1]]
             p2 = t[i][tetpairs[ep][2]]
@@ -58,7 +58,7 @@ function tet_to_edges!(pair::Vector, pair_set::Set, t)
     resize!(pair, length(pair_set))
     # copy pair set to array since sets are not sortable
     i = 1
-    for elt in pair_set
+    @inbounds for elt in pair_set
         pair[i] = elt
         i = i + 1
     end

--- a/src/distmeshnd.jl
+++ b/src/distmeshnd.jl
@@ -205,7 +205,7 @@ function retriangulate!(fdist, result::DistMeshResult, geps, setup, triangulatio
     # TODO: can we use the point distance array to pass boundary points to
     #        tetgen so this call is no longer required?
     j = firstindex(t)
-    for ai in t
+    @inbounds for ai in t
         t[j] = ai
         pm = (p[ai[1]].+p[ai[2]].+p[ai[3]].+p[ai[4]])./4
         j = ifelse(fdist(pm) <= -geps, nextind(t, j), j)
@@ -224,7 +224,7 @@ function compute_displacements!(fh, dp, pair, L, L0, bars, p, setup,
     # Lp norm (p=3) is partially computed here
     Lsum = zero(eltype(L))
     L0sum = non_uniform ? zero(eltype(L0)) : length(pair)
-    for i in eachindex(pair)
+    @inbounds for i in eachindex(pair)
         pb = pair[i]
         b1 = p[pb[1]]
         b2 = p[pb[2]]
@@ -237,7 +237,7 @@ function compute_displacements!(fh, dp, pair, L, L0, bars, p, setup,
     end
 
     # zero out force at each node
-    for i in eachindex(dp)
+    @inbounds for i in eachindex(dp)
         dp[i] = zero(VertType)
     end
 
@@ -246,7 +246,7 @@ function compute_displacements!(fh, dp, pair, L, L0, bars, p, setup,
     lscbrt = (1+(0.4/2^2))*cbrt(Lsum/L0sum)
 
     # Move mesh points based on edge lengths L and forces F
-    for i in eachindex(pair)
+    @inbounds for i in eachindex(pair)
         if non_uniform && L[i] < L0[i]*lscbrt || L[i] < lscbrt
             L0_f = non_uniform ? L0[i].*lscbrt : lscbrt
             # compute force vectors

--- a/src/distmeshnd.jl
+++ b/src/distmeshnd.jl
@@ -84,7 +84,7 @@ function distmesh(fdist::Function,
                             stats ? DistMeshStatistics() : nothing)
 
     # initialize arrays
-    pair_set = Set{Tuple{Int32,Int32}}()        # set used for ensure we have a unique set of edges
+    pair_set = Set{UInt64}()        # set used for ensure we have a unique set of edges
     pair = Tuple{Int32,Int32}[]                 # edge indices (Int32 since we use Tetgen)
     dp = zeros(VertType, length(p))             # displacement at each node
     bars = VertType[]                           # the vector of each edge


### PR DESCRIPTION
The sort call turns out to be highly suspect for certain cases, so disable. This also includes bit pack to accelerate hashing. Since sorting has no apparent benefit, directly using sets for edge pair iteration should be tested as well (and remove the bit packing).